### PR TITLE
Fix git modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "vendor/github.com/Jalle19/upcloud-go-sdk"]
 	path = vendor/github.com/Jalle19/upcloud-go-sdk
 	url = https://github.com/Jalle19/upcloud-go-sdk.git
+	branch = 1.1.0
 [submodule "vendor/gopkg.in/yaml.v2"]
 	path = vendor/gopkg.in/yaml.v2
 	url = https://gopkg.in/yaml.v2
+	branch = v2
 [submodule "vendor/github.com/Sirupsen/logrus"]
 	path = vendor/github.com/Sirupsen/logrus
 	url = https://github.com/sirupsen/logrus.git
+	branch = v0.11.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "vendor/github.com/Jalle19/upcloud-go-sdk"]
+	path = vendor/github.com/Jalle19/upcloud-go-sdk
+	url = https://github.com/Jalle19/upcloud-go-sdk.git
+[submodule "vendor/gopkg.in/yaml.v2"]
+	path = vendor/gopkg.in/yaml.v2
+	url = https://gopkg.in/yaml.v2
+[submodule "vendor/github.com/Sirupsen/logrus"]
+	path = vendor/github.com/Sirupsen/logrus
+	url = https://github.com/sirupsen/logrus.git


### PR DESCRIPTION
This patch adds a proper git submodules description, which should fix some git errors when using golang vendor paths.